### PR TITLE
copr-sig: Promote `niedhui` from Active contributor to Reviewer

### DIFF
--- a/sig/coprocessor/membership.md
+++ b/sig/coprocessor/membership.md
@@ -15,13 +15,12 @@ None
 
 ## Reviewers
 
-None
+- [@niedhui](https://github.com/niedhui)
 
 ## Active Contributors
 
 - [@hawkingrei](http://github.com/hawkingrei)
 - [@koushiro](http://github.com/koushiro)
-- [@niedhui](https://github.com/niedhui)
 - [@TennyZhuang](https://github.com/TennyZhuang)
 
 ## Former Members


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

I nominated to promote  [@niedhui](https://github.com/niedhui) from active contributor to reviewer, as niedhui's contribution to tikv has reached the [reviewer's standard]( [@niedhui](https://github.com/niedhui)).

- Merged [35 PRs](https://github.com/tikv/tikv/pulls?q=is%3Apr+author%3Aniedhui+is%3Aclosed)
- https://github.com/tikv/tikv/pull/5725 (A High PCP task)
