### PR TITLE
Add @cireu to coprocessor-sig active contributor.

### DIFF
--- a/sig/coprocessor/membership.md
+++ b/sig/coprocessor/membership.md
@@ -22,6 +22,7 @@ None
 
 - [@hawkingrei](http://github.com/hawkingrei)
 - [@koushiro](http://github.com/koushiro)
+- [@cireu](https://github.com/cireu)
 
 ## Former Members
 


### PR DESCRIPTION
Signed-off-by: Zhu Zihao <all_but_last@163.com>

I am Zhu Zihao, an independent developer. Start contributing to TiKV since Nov 12, 2019.

I submit multipe PRs to the coprocessor component of TiKV.

PCP(Easy)

- https://github.com/tikv/tikv/pull/5872
- https://github.com/tikv/tikv/pull/5894
- https://github.com/tikv/tikv/pull/5899
- https://github.com/tikv/tikv/pull/5946
- https://github.com/tikv/tikv/pull/5978
- https://github.com/tikv/tikv/pull/6012
- https://github.com/tikv/tikv/pull/6109
- https://github.com/tikv/tikv/pull/6130

Bugfixes:

- https://github.com/tikv/tikv/pull/5999
- https://github.com/tikv/tikv/pull/6032

This PR adds me to the list of coprocessor-sig active contributor. I have read  following documents and understood the expectation of an active contributor.

- https://github.com/tikv/community/blob/master/sig/coprocessor/workflow-zh_CN.md 
- https://github.com/tikv/community/blob/master/sig/coprocessor/charter-zh_CN.md  
- https://github.com/tikv/community/blob/master/GOVERNANCE-zh_CN.md