### PR TITLE
Promote @TennyZhuang to Coprocessor Committer

### DIFF
--- a/sig/coprocessor/membership.md
+++ b/sig/coprocessor/membership.md
@@ -12,10 +12,9 @@ None
 ## Committers
 
 - [@niedhui](https://github.com/niedhui)
+- [@TennyZhuang](https://github.com/TennyZhuang)
 
 ## Reviewers
-
-- [@TennyZhuang](https://github.com/TennyZhuang)
 
 ## Active Contributors
 


### PR DESCRIPTION
@TennyZhuang is a new star in Coprocessor SIG and very well known recently. He has notably drived many important projects, like:

- Greatly improved LIKE() performance: https://github.com/tikv/tikv/pull/5866
- Greatly improved IN() performance: https://github.com/tikv/tikv/pull/6000
- Refine TiDB's Time format to be 8 bytes as TiKV: https://github.com/tikv/tikv/pull/6418

He is also currently working on:

- Participant in implementing collation for TiKV: https://github.com/tikv/tikv/pull/6592
- Accept RPN expression to support complex expressions: https://github.com/tikv/tikv/pull/6313
- Implement the metadata framework: https://github.com/tikv/tikv/pull/5993

In addition, he also helped other contributors and reviewed several PRs for them. He is an expert on the Coprocessor module now. For this reason, I nominate to promote him as a committer.