### PR TITLE
add member renkai

### DIFF
--- a/sig/coprocessor/membership.md
+++ b/sig/coprocessor/membership.md
@@ -23,6 +23,7 @@ None
 - [@hawkingrei](http://github.com/hawkingrei)
 - [@koushiro](http://github.com/koushiro)
 - [@cireu](https://github.com/cireu)
+- [@renkai](https://github.com/renkai)
 
 ## Former Members
 


### PR DESCRIPTION
My name is Ge Renkai from Fordeal. I first contribute to TiKV since around Aug, 2018.

I submit multiple PR to tikv:
* https://github.com/tikv/tikv/pull/6341
* https://github.com/tikv/tikv/pull/6163
* https://github.com/tikv/tikv/pull/5979
* https://github.com/tikv/rust-prometheus/pull/297
* https://github.com/tikv/rust-prometheus/pull/296

This PR adds me to the list of coprocessor-sig active contributor. I have read and understand the expectations of active contributor described in the https://github.com/tikv/community/blob/master/committee/sig-governance/SIG-GOVERNACE.md.