### PR TITLE
A transition for Coprocessor SIG leadership

### DIFF
--- a/sig/coprocessor/membership.md
+++ b/sig/coprocessor/membership.md
@@ -2,18 +2,16 @@
 
 ## Tech Leader
 
-- [@breeswish](https://github.com/breeswish)
-- [@lonng](https://github.com/lonng)
-
-## Maintainers
-
-None
+- [@breeswish](https://github.com/breeswish) (PingCAP)
+- Probation: [@SunRunAway](https://github.com/SunRunAway) (PingCAP)
+- Probation: [@lzmhhh123](https://github.com/lzmhhh123) (PingCAP)
 
 ## Committers
 
 - [@niedhui](https://github.com/niedhui)
 - [@TennyZhuang](https://github.com/TennyZhuang)
 
+- [@lonng](https://github.com/lonng) (PingCAP, previous Tech Leader)
 - [@sticnarf](https://github.com/sticnarf) (PingCAP)
 - [@zhongzc](https://github.com/zhongzc) (PingCAP)
 - [@iosmanthus](https://github.com/iosmanthus) (PingCAP)


### PR DESCRIPTION
Changes:

1. @lonng is currently leading TiUP and other TiDB delivery affairs, so that he is stepped down as a Committer instead of Tech leader.
2. The Coprocessor SIG will be led by @SunRunAway and @lzmhhh123 comes from TiDB team in future so that TiDB and TiKV can better work together.  They will lead the Coprocessor SIG in the following 2 forms:
   - Develop: Currently they are not familiar enough to the Coprocessor code base, so that they are in probation stage. They will follow the same way as other contributors, i.e. from active contributor -> reviewer -> committer. The probation stage ends when they are qualified to be a committer. We hope this transition can finish by the end of Q3.
   - Manage: Starting from now, they will deeply participant in planning, designing, growing and operating the Coprocessor SIG.