### PR TITLE
Promote @skyzh to Coprocessor committer

### DIFF
--- a/sig/coprocessor/membership.md
+++ b/sig/coprocessor/membership.md
@@ -10,6 +10,7 @@
 
 - [@niedhui](https://github.com/niedhui)
 - [@TennyZhuang](https://github.com/TennyZhuang)
+- [@skyzh](https://github.com/skyzh)
 
 - [@lonng](https://github.com/lonng) (PingCAP, previous Tech Leader)
 - [@sticnarf](https://github.com/sticnarf) (PingCAP)
@@ -30,7 +31,6 @@
 - [@renkai](https://github.com/renkai)
 - [@codeworm96](https://github.com/codeworm96)
 - [@Rustin-Liu](https://github.com/Rustin-Liu)
-- [@skyzh](https://github.com/skyzh)
 
 ## Former Members
 


### PR DESCRIPTION
@skyzh is the most talented contributor I have seen so far in the Coprocessor SIG. This PR promotes him directly from Active Contributor to Committer in the Coprocessor SIG for his impressive and outstanding contribution for the [Full Chunk based computing](https://github.com/tikv/tikv/issues/7724) task, which is also a CNCF CommunityBridge project.

Highlights:

- A huge refactor (5000+ LOC) with a well-organized and incremental style of change, PR by PR, reveals good understanding of the whole architecture and technical details.
- Almost in the right and nice direction all the time -- I left only very few comments to request for change for his refactoring work.

[A list of all PRs he has worked with](https://github.com/tikv/tikv/pulls?q=is%3Apr+author%3Askyzh).