### PR TITLE
sig: migrate scheduling SIG from PingCAP to TiKV

### DIFF
--- a/sig/scheduling/README.md
+++ b/sig/scheduling/README.md
@@ -1,8 +1,8 @@
 # Scheduling Special Interest Group(Scheduling SIG)
 
-Scheduling SIG covers the scheduling system in TiDB cluster. Our work includes
+Scheduling SIG covers the scheduling system for TiKV. Our work includes
 
-- Supporting new scheduling policies or optimizing the existing scheduling system.
+- Supporting new scheduling policies and optimizing the existing scheduling systems.
 - Engineering optimizations.
 
 ## Roles and Organization Management

--- a/sig/scheduling/README.md
+++ b/sig/scheduling/README.md
@@ -1,0 +1,29 @@
+# Scheduling Special Interest Group(Scheduling SIG)
+
+Scheduling SIG covers the scheduling system in TiDB cluster. Our work includes
+
+- Supporting new scheduling policies or optimizing the existing scheduling system.
+- Engineering optimizations.
+
+## Roles and Organization Management
+
+- [SIG Scheduling Constitution](./constitution.md).
+- [SIG Scheduling Constitution (zh-CN)](./constitution-zh_CN.md).
+
+## Members
+
+See [SIG Scheduling Members](./membership.md).
+
+## Meetings
+
+- TBD
+
+## Contact
+
+- Slack: channel [#sig-scheduling](https://slack.tidb.io/invite?team=tidb-community&channel=sig-scheduling&ref=github-sig) in the [tidbcommunity](https://tidbcommunity.slack.com/archives/CVBRYUP9B) slack workspace.
+
+## Code Locations
+
+- [pd](https://github.com/tikv/pd)
+- [pd_client](https://github.com/tikv/tikv/tree/master/components/pd_client)
+- [kvproto](https://github.com/pingcap/kvproto)

--- a/sig/scheduling/README.md
+++ b/sig/scheduling/README.md
@@ -20,7 +20,7 @@ See [SIG Scheduling Members](./membership.md).
 
 ## Contact
 
-- Slack: channel [#sig-scheduling](https://slack.tidb.io/invite?team=tidb-community&channel=sig-scheduling&ref=github-sig) in the [tidbcommunity](https://tidbcommunity.slack.com/archives/CVBRYUP9B) slack workspace.
+- Slack: channel [#sig-scheduling](https://slack.tidb.io/invite?team=tikv-wg&channel=sig-scheduling&ref=pingcap-community) in the [tikv-wg](https://app.slack.com/client/TDE5RV3FF) slack workspace.
 
 ## Code Locations
 

--- a/sig/scheduling/constitution-zh_CN.md
+++ b/sig/scheduling/constitution-zh_CN.md
@@ -29,7 +29,7 @@ Scheduling SIG 的主要职责是致力于调度系统 [pd](https://github.com/t
 
 - 定期同步进度
   - 每 2 周以文档形式同步一次当前各个项目的开发进度。
-  - Slack: [#sig-scheduling](https://slack.tidb.io/invite?team=tidb-community&channel=sig-scheduling&ref=github-sig)
+  - Slack: [#sig-scheduling](https://slack.tidb.io/invite?team=tikv-wg&channel=sig-scheduling&ref=pingcap-community)
 
 - 组织线上线下成员的活动
 - Tech Leads 额外承担的职责

--- a/sig/scheduling/constitution-zh_CN.md
+++ b/sig/scheduling/constitution-zh_CN.md
@@ -1,0 +1,78 @@
+# Scheduling SIG 章程
+
+本章程遵循 TiKV Community 章程和制度，使用 [SIG Governance](/GOVERNANCE-zh_CN.md) 中的角色定义以及职责。
+
+## 职责范围
+
+Scheduling SIG 的主要职责是致力于调度系统 [pd](https://github.com/tikv/pd) 的发展，优化调度算法和改进工程实现，并组织社区成员进行相关开发和维护。仅 Active Contributor 或更高等级社区成员可成为 SIG 成员并参与到相应事项中来，但 SIG 各项实行的决策和进行的项目将公开。
+
+## 工作内容
+
+- 代码范围
+  - [pd](https://github.com/tikv/pd): 调度实现。
+  - [pd_client](https://github.com/tikv/tikv/tree/master/components/pd_client): PD client 的实现。
+
+- 测试规范
+  - 提交代码需包括必要的单元测试。合并代码前需保证 CI 全部通过。
+  - 对于影响性能的改动，需提供必要的性能测试结果。
+
+- 设计与演进 Proposal
+- Review 相关项目代码
+
+## 其他规章流程
+
+- 代码风格、提交规范、PR Description 模板等请参考 [文档](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md)
+- 任务分配
+  - SIG Tech Lead 在 https://github.com/tikv/community 维护公开的 [成员列表](./membership.md) 与 [任务列表](https://github.com/tikv/pd/projects/5) 链接。
+  - 新加入的 SIG 成员可自由领取任务，或参与现有任务的开发或推动，但需与 Tech Lead 或相应任务的负责人进行沟通和同步。
+  - SIG 成员需维持每个月参与开发任务，或参与关于现有功能或未来规划的设计与讨论。若连续一个季度不参与开发与讨论，视为不活跃状态，视情况将会被移除 SIG。
+
+- 定期同步进度
+  - 每 2 周以文档形式同步一次当前各个项目的开发进度。
+  - Slack: [#sig-scheduling](https://slack.tidb.io/invite?team=tidb-community&channel=sig-scheduling&ref=github-sig)
+
+- 组织线上线下成员的活动
+- Tech Leads 额外承担的职责
+  - SIG 成员提出的问题需要在 2 个工作日给出回复
+  - 及时 Review 设计文档和代码
+  - 定时发布任务（如果 SIG member 退出后，未完成的任务需要重新分配）
+
+## SIG 活跃规则，晋升机制
+
+- 考核 & 晋升制度
+  - Tech Leader 以月为单位对小组成员进行考核，决定成员是否可由 Contributor 晋升为 Active Contributor：
+    - 获得至少 2 位 TiKV Reviewer 的提名
+    - PR 贡献满足以下条件：
+      - 一年内合并 PD 相关 PR 总数超过 8 个
+
+  - Tech Leader 以月为单位对小组成员进行考核，决定成员是否可由 Active Contributor 晋升为 Reviewer：
+    - 获得至少 2 位 TiKV Committer 的提名
+    - PR 贡献满足以下任意一点：
+      - 合并 PD 相关 PR 总数超过 20 个
+      - 完成一个重要的 issue
+
+  - Tech Leader 和 TiKV Maintainer 以季度为单位对小组成员进行考核，决定成员是否可由 Reviewer 晋升为 Committer：
+    - 获得至少 2 位 TiKV Maintainer 的提名
+    - PR 贡献满足以下至少两点：
+      - 独立或领导完成两项重要 feature
+      - 修复一个重大 bug
+      - 有效 Review PD 相关 PR 总数超过 20 个
+      - 合并 PD 相关 PR 总数超过 40 个
+
+- 晋级角色权益 & 义务
+  - Reviewer
+    - 参与项目设计决策
+    - 参与 PD 相关 PR Review 与质量控制
+    - 对 PD 相关 PR 具有有效的 Approve / Request Change 权限
+
+  - Committer
+    - 拥有 Reviewer 具有的权益与义务
+    - 整体把控项目的代码质量
+    - 指导 Contributor 与 Reviewer
+
+- 退出制度
+  - SIG 成员在以下情况中会被移除 SIG，但保留相应的 Active Contributor / Reviewer / Committer 身份：
+    - 连续一个季度处于不活跃状态
+
+  - Reviewer 满足以下条件之一会被取消 Reviewer 身份且收回权限（后续重新考核后可恢复）：
+    - 有 2 位以上 Committer 认为 Reviewer 能力不足或活跃度不足

--- a/sig/scheduling/constitution.md
+++ b/sig/scheduling/constitution.md
@@ -29,7 +29,7 @@ The main responsibility of Scheduling SIG is to work on the development of the s
 
 - Regular sync progress, regular weekly meetings
   - Synchronize the current development progress of each project as a document every 2 weeks.
-  - Slack: [#sig-scheduling](https://slack.tidb.io/invite?team=tidb-community&channel=sig-scheduling&ref=github-sig)
+  - Slack: [#sig-scheduling](https://slack.tidb.io/invite?team=tikv-wg&channel=sig-scheduling&ref=pingcap-community)
 
 - Organize events for online and offline members
 - Additional responsibilities for Tech Leads

--- a/sig/scheduling/constitution.md
+++ b/sig/scheduling/constitution.md
@@ -1,0 +1,78 @@
+# Scheduling SIG Bylaws
+
+This charter follows the TiKV Community charter and system, using the role definitions and responsibilities in [SIG Governance](/GOVERNANCE.md).
+
+## Responsibility
+
+The main responsibility of Scheduling SIG is to work on the development of the scheduling system [pd](https://github.com/tikv/pd) through optimizing the scheduling algorithm and implementation, and organize the community Members carry out related development and maintenance. Only members of the Active Contributor or higher community can become members of the SIG and participate in relevant matters, but the decisions and projects implemented by the SIG will be made public.
+
+## Work content
+
+- Code
+  - [pd](https://github.com/tikv/pd): Implementation of scheduling.
+  - [pd_client](https://github.com/tikv/tikv/tree/master/components/pd_client): Implementation of PD client.
+
+- Test Specification
+  - Submit code to include necessary unit tests. Make sure all CIs pass before merging the code.
+  - For changes that affect performance, provide the necessary performance test results.
+
+- Design and Evolution Proposal
+- Review related project code
+
+## Other regulatory processes
+
+- Code style, submission specifications, PR Description template, etc. please refer to [Document](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md)
+- Task Assignment
+  - SIG Tech Lead maintains public [Member List](./membership.md) and [Task List](https://github.com/tikv/pd/projects/5) Link.
+  - New SIG members can freely receive tasks, or participate in the development or promotion of existing tasks, but need to communicate and synchronize with the Tech Lead or the person responsible for the corresponding task.
+  - SIG members are required to maintain monthly participation in development tasks or to participate in the design and discussion of existing features or future plans. If you do not participate in development and discussion for a quarter of a year, it is considered inactive and SIG will be removed as appropriate.
+
+- Regular sync progress, regular weekly meetings
+  - Synchronize the current development progress of each project as a document every 2 weeks.
+  - Slack: [#sig-scheduling](https://slack.tidb.io/invite?team=tidb-community&channel=sig-scheduling&ref=github-sig)
+
+- Organize events for online and offline members
+- Additional responsibilities for Tech Leads
+  - Questions from SIG members need to respond within 2 business days
+  - Review design documents and code in a timely manner
+  - Schedule tasks (if SIG member exits, unfinished tasks need to be reassigned)
+
+## SIG Active Rules, Promotion Mechanism
+
+- Assessment & Promotion System
+  - Tech Leader evaluates group members on a monthly basis to determine whether members can be promoted to Active Contributor from Contributor:
+    - Nominated by at least 2 TiKV Reviewers
+    - PR contributions meet the following condition:
+      - Combined PD-related PR totals over 8 in a year
+
+  - Tech Leader evaluates group members on a monthly basis to determine whether members can be promoted to Reviewer from Active Contributor:
+    - Nominated by at least 2 TiKV Committers
+    - PR contributions meet any of the following:
+      - Combined PD-related PR totals over 20
+      - Finish at least one important issue
+
+  - Tech Leader and TiKV Maintainer evaluate team members on a quarterly basis to determine whether members can be promoted to Committer from Reviewer:
+    - Nominated for at least 2 TiKV Maintainers
+    - PR contributions meet at least two of the following:
+      - Complete two important features independently or lead
+      - Fix a major bug
+      - More than 20 total review PD related PRs
+      - Combined PD-related PR totals over 40
+
+- Promotion Role Rights & Obligations
+  - Reviewer
+    - Participate in project design decisions
+    - Participate in PR review and quality control related to PD
+    - Valid Approve / Request Change permissions for PD related PR
+
+  - Committer
+    - Owning the rights and obligations of Reviewer
+    - Control the overall code quality of the project
+    - Guide Contributor and Reviewer
+
+- Exit
+  - SIG members are removed from SIG in the following cases, but retain the corresponding Active Contributor / Reviewer / Committer status:
+    - Inactive for one consecutive quarter
+
+  - Reviewer will be revoked and revoked if one of the following conditions is met:
+    - 2 or more Committers consider Reviewer insufficient or active

--- a/sig/scheduling/membership.md
+++ b/sig/scheduling/membership.md
@@ -1,0 +1,37 @@
+# Scheduling SIG Members
+
+**NOTE**:
+
+* This member list is updated on a monthly basis.
+* Last update time: 2020-08-20
+
+## SIG Leader
+
+* [rleungx](https://github.com/rleungx), [PingCAP](https://pingcap.com/en/)
+
+## Maintainers
+
+None
+
+## Committers
+
+* [nolouch](https://github.com/nolouch), [PingCAP](https://pingcap.com/en/)
+* [disksing](https://github.com/disksing), [PingCAP](https://pingcap.com/en/)
+* [lhy1024](https://github.com/lhy1024), [PingCAP](https://pingcap.com/en/)
+* [HunDunDM](https://github.com/HunDunDM), [PingCAP](https://pingcap.com/en/)
+* [siddontang](https://github.com/siddontang), [PingCAP](https://pingcap.com/en/)
+* [qiuyesuifeng](https://github.com/qiuyesuifeng), [PingCAP](https://pingcap.com/en/)
+* [huachaohuang](https://github.com/huachaohuang)
+* [overvenus](https://github.com/overvenus), [PingCAP](https://pingcap.com/en/)
+* [Connor1996](https://github.com/Connor1996), [PingCAP](https://pingcap.com/en/)
+
+## Reviewers
+
+* [Luffbee](https://github.com/Luffbee)
+* [shafreeck](https://github.com/shafreeck)
+
+## Active Contributors
+
+* [mantuliu](https://github.com/mantuliu), [Hive Box](https://www.fcbox.com/en)
+* [JmPotato](https://github.com/JmPotato), [PingCAP](https://pingcap.com/en/)
+* [Yisaer](https://github.com/Yisaer), [PingCAP](https://pingcap.com/en/)


### PR DESCRIPTION
This PR is going to migrate scheduling SIG from PingCAP to TiKV.