### PR TITLE
add one new reviews for raft sig.

### DIFF
--- a/sig/raft/membership.md
+++ b/sig/raft/membership.md
@@ -20,6 +20,7 @@ None
 ## Reviewers
 
 - [Fullstop000](https://github.com/Fullstop000)
+- [accelsao](https://github.com/accelsao)
 
 ## Active Contributors
 
@@ -32,6 +33,7 @@ None
 - [nrc](https://github.com/nrc)
 - [ice1000](https://github.com/ice1000)
 - [csmoe](https://github.com/csmoe)
+- [accelsao](https://github.com/accelsao)
 
 ## Contributors
 


### PR DESCRIPTION
@accelsao ported datadriven tests from cockroachdb and also did many
works about joint-consensus.

Signed-off-by: qupeng <qupeng@pingcap.com>