### PR TITLE
sig-scheduling: promote howardlau1999 to reviewer

### DIFF
--- a/sig/scheduling/membership.md
+++ b/sig/scheduling/membership.md
@@ -32,6 +32,7 @@ None
 * [shafreeck](https://github.com/shafreeck)
 * [JmPotato](https://github.com/JmPotato), [PingCAP](https://pingcap.com/en/)
 * [xhebox](https://github.com/xhebox)
+* [howardlau1999](https://github.com/howardlau1999), [PingCAP](https://pingcap.com/en/)
 
 ## Active Contributors
 


### PR DESCRIPTION
@howardlau1999 has done a lot of work for auto scaling and we are going to promote him as a reviewer. His mainly work includes:

- help finish the implementation of auto scaling in pd and tidb-operator
- refine the log format
- fix several bugs

All his work can be found in [pd](https://github.com/tikv/pd/pulls?q=is%3Apr+author%3Ahowardlau1999+is%3Aclosed) and [tidb-operator](https://github.com/pingcap/tidb-operator/pulls/howardlau1999).


