### PR TITLE
Promote skyzh to coLeader

### DIFF
--- a/sig/coprocessor/membership.json
+++ b/sig/coprocessor/membership.json
@@ -7,6 +7,9 @@
   ],
   "coLeaders": [
     {
+      "githubName": "skyzh"
+    },
+    {
       "githubName": "SunRunAway"
     },
     {
@@ -19,9 +22,6 @@
     },
     {
       "githubName": "TennyZhuang"
-    },
-    {
-      "githubName": "skyzh"
     },
     {
       "githubName": "lonng"


### PR DESCRIPTION
@skyzh is now the de facto Coprocessor leader, who leads the development, mentoring and reviewing happens in Coprocessor

This PR promotes him to the co-leader.