### PR TITLE
Promote @Xuanwo to sig-copr reviewer

### DIFF
--- a/sig/coprocessor/membership.json
+++ b/sig/coprocessor/membership.json
@@ -42,6 +42,9 @@
   "reviewers": [
     {
       "githubName": "Fullstop000"
+    },
+    {
+      "githubName": "Xuanwo"
     }
   ],
   "activeContributors": [
@@ -62,9 +65,6 @@
     },
     {
       "githubName": "hi-rustin"
-    },
-    {
-      "githubName": "Xuanwo"
     }
   ]
 }


### PR DESCRIPTION
@Xuanwo is the mentee for [2020 Q3-Q4 CNCF Community Bridge](https://github.com/cncf/mentoring/blob/master/communitybridge/2020/q3-q4/selected_projects.md) project. In past two months, he added [ENUM / SET support](https://github.com/tikv/tikv/issues/8605) for coprocessor.

Here is a list of PRs he has worked on for the Community Bridge project.

* https://github.com/tikv/tikv/pull/8728
* https://github.com/tikv/tikv/pull/8740
* https://github.com/tikv/tikv/pull/8849
* https://github.com/tikv/tikv/pull/8948
* https://github.com/tikv/tikv/pull/8951
* https://github.com/tikv/tikv/pull/8988
* https://github.com/tikv/tikv/pull/9021
* https://github.com/tikv/tikv/pull/9133
* https://github.com/tikv/tikv/pull/9135
* https://github.com/tikv/tikv/pull/9143
* https://github.com/tikv/tikv/pull/9146
* https://github.com/tikv/tikv/pull/9148
* https://github.com/tikv/tikv/pull/9184
* https://github.com/tikv/tikv/pull/9186

He also takes an active part in the community. He reviewed a lot of PRs from other members in community, and he helped phase out legacy non-vectorized execution framework. For example,

* https://github.com/tikv/tikv/pull/8992
* https://github.com/tikv/tikv/pull/8997
* https://github.com/tikv/tikv/pull/9179

@Xuanwo has a good understanding of current coprocessor codebase, and takes an active part in the community. Therefore, I nominate him as sig-copr reviewer.

Signed-off-by: Alex Chi <iskyzh@gmail.com>