### PR TITLE
Make zyguan reviewer for sig-transaction

### DIFF
--- a/sig/transaction/membership.json
+++ b/sig/transaction/membership.json
@@ -59,6 +59,9 @@
     },
     {
       "githubName": "you06"
+    },
+    {
+      "githubName": "zyguan"
     }
   ],
   "activeContributors": []


### PR DESCRIPTION
Zyguan has raised many issues(50+) for TiDB transaction and execution layer and made great contributions to the transaction test utilities like [jepsen](https://github.com/PingCAP-QE/jepsen) tests, tipocket, [tp-test](https://github.com/zyguan/go-randgen/tree/tp-test/tp-test), etc.
So we would like to promote him to the transaction sig reviewer.