### PR TITLE
Promote @wangggong to sig-copr active contributor

### DIFF
--- a/sig/coprocessor/membership.json
+++ b/sig/coprocessor/membership.json
@@ -65,6 +65,9 @@
     },
     {
       "githubName": "hi-rustin"
+    },
+    {
+      "githubName": "wangggong"
     }
   ]
 }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

@wangggong has been actively contributed to TiKV coprocessor since September, 2020. Here is a list of PR they have been worked with, including vectorizing date-time-related functions and string-related functions.

https://github.com/tikv/tikv/pulls?q=is%3Apr+author%3Awangggong

* https://github.com/tikv/tikv/pull/8144
* https://github.com/tikv/tikv/pull/8192
* https://github.com/tikv/tikv/pull/8999
* https://github.com/tikv/tikv/pull/9065
* https://github.com/tikv/tikv/pull/9085
* https://github.com/tikv/tikv/pull/9087
* https://github.com/tikv/tikv/pull/9141
* https://github.com/tikv/tikv/pull/9238
* https://github.com/tikv/tikv/pull/9370
* https://github.com/tikv/tikv/pull/9474

Therefore, I would like to promote @wangggong as active contributor.