### PR TITLE
coprocessor: add Jibbow to Coprocessor reviewer

### DIFF
--- a/sig/coprocessor/membership.json
+++ b/sig/coprocessor/membership.json
@@ -54,6 +54,9 @@
     },
     {
       "githubName": "wshwsh12"
+    },
+    {
+      "githubName": "Jibbow"
     }
   ],
   "activeContributors": [


### PR DESCRIPTION
@Jibbow is the mentee for [LFX Mentorship 2021 Spring](https://github.com/cncf/mentoring/blob/master/lfx-mentorship/2021/01-Spring/README.md). He added [coprocessor plugin support](https://github.com/tikv/tikv/issues/8036) (or so-called coprocessor v2) to TiKV. 

Prior to the mentorship, Andreas takes an active part in TiKV community and added a lot of operators for TiKV coprocessor. One of the most notable contributions is adding [variance function support](https://github.com/tikv/tikv/pull/9642) to TiKV coprocessor, which is [a long-missing piece](https://github.com/tikv/tikv/issues/4822) among push-down aggregation operators. <del>(Looking for someone integrating this with TiDB push-down plan later.)</del>

* https://github.com/tikv/tikv/pull/9634
* https://github.com/tikv/tikv/pull/9635
* https://github.com/tikv/tikv/pull/9637
* https://github.com/tikv/tikv/pull/9642

When working on TiKV coprocessor plugin project, Andreas made a clear plan, communicated his ideas with our community very well, and finished all work way ahead of time. He came up with cool ideas that impressed us a lot. Here are the PRs he worked with on copr-plugin.

* https://github.com/tikv/tikv/pull/9781
* https://github.com/tikv/tikv/pull/9802
* https://github.com/tikv/tikv/pull/9912
* https://github.com/tikv/tikv/pull/9925
* https://github.com/tikv/tikv/pull/9989
* https://github.com/tikv/tikv/pull/10075
* https://github.com/tikv/tikv/pull/10090
* https://github.com/tikv/tikv/pull/10112

Besides, he also contributed to other parts of TiKV, including validating configuration and fixing docs.

* https://github.com/tikv/tikv/pull/10010
* https://github.com/tikv/tikv/pull/9783

Therefore, I propose to promote him to reviewer of sig-copr.