### PR TITLE
move match_template to tikv org

### DIFF
--- a/teams/tikv/team.json
+++ b/teams/tikv/team.json
@@ -102,6 +102,7 @@
         "jepsen-test",
         "jemalloc",
         "jemallocator",
+        "match-template",
         "minitrace-go",
         "minitrace-rust",
         "minstant",

--- a/votes/0179-move-match-template.md
+++ b/votes/0179-move-match-template.md
@@ -10,8 +10,9 @@ The vote will be open for at least 6 days unless there is an objection or not en
 
 ## Result
 
-Approved by 2 binding votes.    
+Approved by 3 binding votes.    
 
 - busyjay (binding)
 - skyzh (binding)
-- tisonkun (binding)
+- andylokandy (binding)
+- tisonkun (non-binding)

--- a/votes/0179-move-match-template.md
+++ b/votes/0179-move-match-template.md
@@ -1,0 +1,17 @@
+# A Vote for moving match_template to tikv org
+
+## Proposal
+
+[match_template](https://github.com/tikv/tikv/tree/master/components/match_template) is a procedural macro that generates repeated match arms by pattern, which is almost the only way to dispatch code path to static types depending on a runtime value. Since it's general enough, I propose to move it to TiKV org and then publish it to crates.io so that the rust community could be benifit from it.
+
+## Deadline
+
+The vote will be open for at least 6 days unless there is an objection or not enough votes.
+
+## Result
+
+Approved by 2 binding votes.    
+
+- busyjay (binding)
+- skyzh (binding)
+- tisonkun (binding)


### PR DESCRIPTION
Move match_template from TiKV components to an independent crate under TiKV org, and publish it to crates.io.

Closes https://github.com/tikv/community/issues/181